### PR TITLE
Fixed 2 issues

### DIFF
--- a/BMP085.cpp
+++ b/BMP085.cpp
@@ -72,9 +72,15 @@ uint32_t BMP085::readRawPressure(void) {
     _delay_ms(26);
 
   raw = read16(BMP085_PRESSUREDATA);
-  raw <<= 8;
-  raw |= read8(BMP085_PRESSUREDATA+2);
-  raw >>= (8 - oversampling);
+  
+  // ---- extra byte XLSB only for BMP085_ULTRAHIGHRES
+  if (oversampling==0) {
+    raw <<= 8;
+    raw |= read8(BMP085_PRESSUREDATA+2);
+    raw >>= (8 - oversampling);
+  }
+  // ---- end of edit
+  
 #if BMP085_DEBUG == 1
   Serial.print("Raw pressure: "); Serial.println(raw);
 #endif
@@ -148,7 +154,11 @@ int32_t BMP085::readPressure(void) {
   if (B7 < 0x80000000) {
     p = (B7 * 2) / B4;
   } else {
-    p = (B7 * 2) / B3;
+// ---- formula not consistent with specification sheet
+//    p = (B7 * 2) / B3;
+    p = (B7 / B4) * 2;
+// ---- end of edit
+ 
   }
   X1 = (p >> 8) * (p >> 8);
   X1 = (X1 * 3038) >> 16;


### PR DESCRIPTION
Fixed 2 issues: 
- extra byte `XLSB` only for `BMP085_ULTRAHIGHRES`
- formula not consistent with specification sheet
