### PR TITLE
You don't beginTransmission/endTransmission to read i2c...

### DIFF
--- a/Adafruit_BMP085.cpp
+++ b/Adafruit_BMP085.cpp
@@ -245,14 +245,12 @@ uint8_t Adafruit_BMP085::read8(uint8_t a) {
 #endif
   Wire.endTransmission(); // end transmission
   
-  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device 
   Wire.requestFrom(BMP085_I2CADDR, 1);// send data n-bytes read
 #if (ARDUINO >= 100)
   ret = Wire.read(); // receive DATA
 #else
   ret = Wire.receive(); // receive DATA
 #endif
-  Wire.endTransmission(); // end transmission
 
   return ret;
 }
@@ -268,7 +266,6 @@ uint16_t Adafruit_BMP085::read16(uint8_t a) {
 #endif
   Wire.endTransmission(); // end transmission
   
-  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device 
   Wire.requestFrom(BMP085_I2CADDR, 2);// send data n-bytes read
 #if (ARDUINO >= 100)
   ret = Wire.read(); // receive DATA
@@ -279,7 +276,6 @@ uint16_t Adafruit_BMP085::read16(uint8_t a) {
   ret <<= 8;
   ret |= Wire.receive(); // receive DATA
 #endif
-  Wire.endTransmission(); // end transmission
 
   return ret;
 }


### PR DESCRIPTION
You don't beginTransmission/endTransmission to read i2c and it messes up TinyWireM. You don't have to do it with Wire either. Read the reference.
