### PR TITLE
Constructor takes optional arguments for i2c pins

### DIFF
--- a/Adafruit_BMP085.cpp
+++ b/Adafruit_BMP085.cpp
@@ -1,32 +1,42 @@
-/*************************************************** 
+/***************************************************
   This is a library for the Adafruit BMP085/BMP180 Barometric Pressure + Temp sensor
 
-  Designed specifically to work with the Adafruit BMP085 or BMP180 Breakout 
+  Designed specifically to work with the Adafruit BMP085 or BMP180 Breakout
   ----> http://www.adafruit.com/products/391
   ----> http://www.adafruit.com/products/1603
 
-  These displays use I2C to communicate, 2 pins are required to  
+  These displays use I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
 #include "Adafruit_BMP085.h"
 
+Adafruit_BMP085::Adafruit_BMP085(uint8_t sda, uint8_t scl) {
+  _sda = sda;
+  _scl = scl;
+}
 Adafruit_BMP085::Adafruit_BMP085() {
+  _sda = -1;
+  _scl = -1;
 }
 
 
 boolean Adafruit_BMP085::begin(uint8_t mode) {
-  if (mode > BMP085_ULTRAHIGHRES) 
+  if (mode > BMP085_ULTRAHIGHRES)
     mode = BMP085_ULTRAHIGHRES;
   oversampling = mode;
 
-  Wire.begin();
+  if(_sda != -1 && _scl != -1){
+    Wire.begin(_sda,_scl);
+  }else{
+    Wire.begin();
+  }
 
   if (read8(0xD0) != 0x55) return false;
 
@@ -83,13 +93,13 @@ uint32_t Adafruit_BMP085::readRawPressure(void) {
 
   write8(BMP085_CONTROL, BMP085_READPRESSURECMD + (oversampling << 6));
 
-  if (oversampling == BMP085_ULTRALOWPOWER) 
+  if (oversampling == BMP085_ULTRALOWPOWER)
     delay(5);
-  else if (oversampling == BMP085_STANDARD) 
+  else if (oversampling == BMP085_STANDARD)
     delay(8);
-  else if (oversampling == BMP085_HIGHRES) 
+  else if (oversampling == BMP085_HIGHRES)
     delay(14);
-  else 
+  else
     delay(26);
 
   raw = read16(BMP085_PRESSUREDATA);
@@ -217,7 +227,7 @@ float Adafruit_BMP085::readTemperature(void) {
   B5 = computeB5(UT);
   temp = (B5+8) >> 4;
   temp /= 10;
-  
+
   return temp;
 }
 
@@ -237,15 +247,15 @@ float Adafruit_BMP085::readAltitude(float sealevelPressure) {
 uint8_t Adafruit_BMP085::read8(uint8_t a) {
   uint8_t ret;
 
-  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device 
+  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device
 #if (ARDUINO >= 100)
   Wire.write(a); // sends register address to read from
 #else
   Wire.send(a); // sends register address to read from
 #endif
   Wire.endTransmission(); // end transmission
-  
-  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device 
+
+  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device
   Wire.requestFrom(BMP085_I2CADDR, 1);// send data n-bytes read
 #if (ARDUINO >= 100)
   ret = Wire.read(); // receive DATA
@@ -260,15 +270,15 @@ uint8_t Adafruit_BMP085::read8(uint8_t a) {
 uint16_t Adafruit_BMP085::read16(uint8_t a) {
   uint16_t ret;
 
-  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device 
+  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device
 #if (ARDUINO >= 100)
   Wire.write(a); // sends register address to read from
 #else
   Wire.send(a); // sends register address to read from
 #endif
   Wire.endTransmission(); // end transmission
-  
-  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device 
+
+  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device
   Wire.requestFrom(BMP085_I2CADDR, 2);// send data n-bytes read
 #if (ARDUINO >= 100)
   ret = Wire.read(); // receive DATA
@@ -285,7 +295,7 @@ uint16_t Adafruit_BMP085::read16(uint8_t a) {
 }
 
 void Adafruit_BMP085::write8(uint8_t a, uint8_t d) {
-  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device 
+  Wire.beginTransmission(BMP085_I2CADDR); // start transmission to device
 #if (ARDUINO >= 100)
   Wire.write(a); // sends register address to read from
   Wire.write(d);  // write data

--- a/Adafruit_BMP085.h
+++ b/Adafruit_BMP085.h
@@ -1,17 +1,17 @@
-/*************************************************** 
+/***************************************************
   This is a library for the Adafruit BMP085/BMP180 Barometric Pressure + Temp sensor
 
-  Designed specifically to work with the Adafruit BMP085 or BMP180 Breakout 
+  Designed specifically to work with the Adafruit BMP085 or BMP180 Breakout
   ----> http://www.adafruit.com/products/391
   ----> http://www.adafruit.com/products/1603
 
-  These displays use I2C to communicate, 2 pins are required to  
+  These displays use I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -35,7 +35,7 @@
 #define BMP085_ULTRAHIGHRES  3
 #define BMP085_CAL_AC1           0xAA  // R   Calibration data (16 bits)
 #define BMP085_CAL_AC2           0xAC  // R   Calibration data (16 bits)
-#define BMP085_CAL_AC3           0xAE  // R   Calibration data (16 bits)    
+#define BMP085_CAL_AC3           0xAE  // R   Calibration data (16 bits)
 #define BMP085_CAL_AC4           0xB0  // R   Calibration data (16 bits)
 #define BMP085_CAL_AC5           0xB2  // R   Calibration data (16 bits)
 #define BMP085_CAL_AC6           0xB4  // R   Calibration data (16 bits)
@@ -45,7 +45,7 @@
 #define BMP085_CAL_MC            0xBC  // R   Calibration data (16 bits)
 #define BMP085_CAL_MD            0xBE  // R   Calibration data (16 bits)
 
-#define BMP085_CONTROL           0xF4 
+#define BMP085_CONTROL           0xF4
 #define BMP085_TEMPDATA          0xF6
 #define BMP085_PRESSUREDATA      0xF6
 #define BMP085_READTEMPCMD          0x2E
@@ -55,6 +55,7 @@
 class Adafruit_BMP085 {
  public:
   Adafruit_BMP085();
+  Adafruit_BMP085(uint8_t sda, uint8_t scl);
   boolean begin(uint8_t mode = BMP085_ULTRAHIGHRES);  // by default go highres
   float readTemperature(void);
   int32_t readPressure(void);
@@ -62,12 +63,14 @@ class Adafruit_BMP085 {
   float readAltitude(float sealevelPressure = 101325); // std atmosphere
   uint16_t readRawTemperature(void);
   uint32_t readRawPressure(void);
-  
+
  private:
   int32_t computeB5(int32_t UT);
   uint8_t read8(uint8_t addr);
   uint16_t read16(uint8_t addr);
   void write8(uint8_t addr, uint8_t data);
+
+  uint8_t _sda, _scl;
 
   uint8_t oversampling;
 

--- a/examples/BMP085test/BMP085test.ino
+++ b/examples/BMP085test/BMP085test.ino
@@ -1,31 +1,35 @@
 #include <Wire.h>
-#include <Adafruit_BMP085.h>
 
-/*************************************************** 
+/***************************************************
   This is an example for the BMP085 Barometric Pressure & Temp Sensor
 
-  Designed specifically to work with the Adafruit BMP085 Breakout 
+  Designed specifically to work with the Adafruit BMP085 Breakout
   ----> https://www.adafruit.com/products/391
 
-  These displays use I2C to communicate, 2 pins are required to  
+  These displays use I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
 // Connect VCC of the BMP085 sensor to 3.3V (NOT 5.0V!)
 // Connect GND to Ground
 // Connect SCL to i2c clock - on '168/'328 Arduino Uno/Duemilanove/etc thats Analog 5
+// 	Or pass a pin as argument one to Adafruit_BMP085
 // Connect SDA to i2c data - on '168/'328 Arduino Uno/Duemilanove/etc thats Analog 4
+// 	Or pass a pin as argument two to Adafruit_BMP085
 // EOC is not used, it signifies an end of conversion
 // XCLR is a reset pin, also not used here
 
+#include <Adafruit_BMP085.h>
+
 Adafruit_BMP085 bmp;
-  
+//Adafruit_BMP085 bmp(12,14);
+
 void setup() {
   Serial.begin(9600);
   if (!bmp.begin()) {
@@ -33,16 +37,16 @@ void setup() {
 	while (1) {}
   }
 }
-  
+
 void loop() {
     Serial.print("Temperature = ");
     Serial.print(bmp.readTemperature());
     Serial.println(" *C");
-    
+
     Serial.print("Pressure = ");
     Serial.print(bmp.readPressure());
     Serial.println(" Pa");
-    
+
     // Calculate altitude assuming 'standard' barometric
     // pressure of 1013.25 millibar = 101325 Pascal
     Serial.print("Altitude = ");
@@ -60,7 +64,7 @@ void loop() {
     Serial.print("Real altitude = ");
     Serial.print(bmp.readAltitude(101500));
     Serial.println(" meters");
-    
+
     Serial.println();
     delay(500);
 }


### PR DESCRIPTION
On some ESP8266 based boards I need to be able to define the i2c pins.
I added a constructor that takes two arguments for `sda` and `scl`, and modified the default constructor to maintain current behavior.


Also, all the trailing whitespace is gone now.