### PR TITLE
Speedup by eliminating delay() calls

### DIFF
--- a/Adafruit-BMP085-Library.ino
+++ b/Adafruit-BMP085-Library.ino
@@ -1,0 +1,66 @@
+#include <Wire.h>
+#include <Adafruit_BMP085.h>
+
+/*************************************************** 
+  This is an example for the BMP085 Barometric Pressure & Temp Sensor
+
+  Designed specifically to work with the Adafruit BMP085 Breakout 
+  ----> https://www.adafruit.com/products/391
+
+  These displays use I2C to communicate, 2 pins are required to  
+  interface
+  Adafruit invests time and resources providing this open source code, 
+  please support Adafruit and open-source hardware by purchasing 
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  BSD license, all text above must be included in any redistribution
+ ****************************************************/
+
+// Connect VCC of the BMP085 sensor to 3.3V (NOT 5.0V!)
+// Connect GND to Ground
+// Connect SCL to i2c clock - on '168/'328 Arduino Uno/Duemilanove/etc thats Analog 5
+// Connect SDA to i2c data - on '168/'328 Arduino Uno/Duemilanove/etc thats Analog 4
+// EOC is not used, it signifies an end of conversion
+// XCLR is a reset pin, also not used here
+
+Adafruit_BMP085 bmp;
+  
+void setup() {
+  Serial.begin(9600);
+  if (!bmp.begin()) {
+	Serial.println("Could not find a valid BMP085 sensor, check wiring!");
+	while (1) {}
+  }
+}
+  
+void loop() {
+    Serial.print("Temperature = ");
+    Serial.print(bmp.readTemperature());
+    Serial.println(" *C");
+    
+    Serial.print("Pressure = ");
+    Serial.print(bmp.readPressure());
+    Serial.println(" Pa");
+    
+    // Calculate altitude assuming 'standard' barometric
+    // pressure of 1013.25 millibar = 101325 Pascal
+    Serial.print("Altitude = ");
+    Serial.print(bmp.readAltitude());
+    Serial.println(" meters");
+
+    Serial.print("Pressure at sealevel (calculated) = ");
+    Serial.print(bmp.readSealevelPressure());
+    Serial.println(" Pa");
+
+  // you can get a more precise measurement of altitude
+  // if you know the current sea level pressure which will
+  // vary with weather and such. If it is 1015 millibars
+  // that is equal to 101500 Pascals.
+    Serial.print("Real altitude = ");
+    Serial.print(bmp.readAltitude(101500));
+    Serial.println(" meters");
+    
+    Serial.println();
+    delay(500);
+}

--- a/Adafruit-BMP085-Library.ino
+++ b/Adafruit-BMP085-Library.ino
@@ -1,5 +1,5 @@
 #include <Wire.h>
-#include <Adafruit_BMP085.h>
+#include "Adafruit_BMP085.h"    // quotes look locally first to avoid clashes
 
 /*************************************************** 
   This is an example for the BMP085 Barometric Pressure & Temp Sensor
@@ -35,6 +35,15 @@ void setup() {
 }
   
 void loop() {
+  static unsigned long last = 0;
+  static unsigned long cnt = 0;
+  bmp.heartBeat();
+  cnt++;
+  if(micros() - last > 1000000L){
+    last = micros();
+    Serial.print(cnt);
+    Serial.print(" times round the loop since last print.\n");
+    cnt = 0;
     Serial.print("Temperature = ");
     Serial.print(bmp.readTemperature());
     Serial.println(" *C");
@@ -62,5 +71,5 @@ void loop() {
     Serial.println(" meters");
     
     Serial.println();
-    delay(500);
+  }
 }

--- a/Adafruit_BMP085.cpp
+++ b/Adafruit_BMP085.cpp
@@ -69,7 +69,7 @@ void Adafruit_BMP085::heartBeat(void) {        // Call when convenient to update
   // incorporates functionality of readRawPressure() and readRawTemperature() to rawT and rawP current
   static byte pending = 0;                     // defines state, nothing, waiting for T, waiting for P
   if(pending == 0){                            // if nothing else going on
-    if(micros()-lastT > 50000){                // update T every 20th of a second
+    if(micros()-lastT > 50000 || lastT == 0){  // update T every 20th of a second
       write8(BMP085_CONTROL, BMP085_READTEMPCMD);
       pending = 1;                  // waiting for temperature when pending = 1
       lastT = micros();

--- a/Adafruit_BMP085.cpp
+++ b/Adafruit_BMP085.cpp
@@ -153,8 +153,8 @@ int32_t Adafruit_BMP085::readPressure(void) {
   //UT = readRawTemperature();
   //UP = readRawPressure();
   heartBeat();
-  while(micros()-lastT > 50000) heartBeat(); // Make sure data is recent
-  while(micros()-lastP > 50000) heartBeat();
+  while(micros()-lastT > 50000 || lastT == 0) heartBeat(); // Make sure data is recent
+  while(micros()-lastP > 50000 || lastP == 0) heartBeat();
   UT = rawT;
   UP = rawP;
 

--- a/Adafruit_BMP085.cpp
+++ b/Adafruit_BMP085.cpp
@@ -59,11 +59,44 @@ boolean Adafruit_BMP085::begin(uint8_t mode) {
   Serial.print("mc = "); Serial.println(mc, DEC);
   Serial.print("md = "); Serial.println(md, DEC);
 #endif
+  readPressure();     // give it time to make at least one initialization reading
+  delay(50);
 
   return true;
 }
 
+void Adafruit_BMP085::heartBeat(void) {        // Call when convenient to update T,P values
+  // incorporates functionality of readRawPressure() and readRawTemperature() to rawT and rawP current
+  static byte pending = 0;                     // defines state, nothing, waiting for T, waiting for P
+  if(pending == 0){                            // if nothing else going on
+    if(micros()-lastT > 50000){                // update T every 20th of a second
+      write8(BMP085_CONTROL, BMP085_READTEMPCMD);
+      pending = 1;                  // waiting for temperature when pending = 1
+      lastT = micros();
+      }
+    else{                           // otherwise start a pressure measurement
+      write8(BMP085_CONTROL, BMP085_READPRESSURECMD + (oversampling << 6));
+      pending = 2;                  // waiting for a pressure measurement when pending = 2 
+      lastP = micros();
+    }
+  } else if(pending == 1){          // read the temperature if it has been long enough
+    if((micros()-lastT)/1000 >= 5){ 
+      rawT = read16(BMP085_TEMPDATA);
+      pending = 0;                  // back to doing nothing
+    }
+  } else if(pending == 2){          // read the pressure if it has been long enough
+    if((micros()-lastP)/1000 >= 2 + 3 * (1 << oversampling)){    // 5,8,14,26 ms for 1,2,4,8 samples
+      rawP = read16(BMP085_PRESSUREDATA);
+      rawP <<= 8;
+      rawP |= read8(BMP085_PRESSUREDATA+2);
+      rawP >>= (8 - oversampling);
+      pending = 0;                  // back to doing nothing
+    }
+  }
+}
+
 int32_t Adafruit_BMP085::computeB5(int32_t UT) {
+  // a function of the raw temperature defined in the datasheet
   int32_t X1 = (UT - (int32_t)ac6) * ((int32_t)ac5) >> 15;
   int32_t X2 = ((int32_t)mc << 11) / (X1+(int32_t)md);
   return X1 + X2;
@@ -116,9 +149,14 @@ uint32_t Adafruit_BMP085::readRawPressure(void) {
 int32_t Adafruit_BMP085::readPressure(void) {
   int32_t UT, UP, B3, B5, B6, X1, X2, X3, p;
   uint32_t B4, B7;
-
-  UT = readRawTemperature();
-  UP = readRawPressure();
+  // use the latest raw values maintained by heartBeat() instead of needing up to 26 ms every call
+  //UT = readRawTemperature();
+  //UP = readRawPressure();
+  heartBeat();
+  while(micros()-lastT > 50000) heartBeat(); // Make sure data is recent
+  while(micros()-lastP > 50000) heartBeat();
+  UT = rawT;
+  UP = rawP;
 
 #if BMP085_DEBUG == 1
   // use datasheet numbers!
@@ -145,7 +183,7 @@ int32_t Adafruit_BMP085::readPressure(void) {
   Serial.print("B5 = "); Serial.println(B5);
 #endif
 
-  // do pressure calcs
+  // do pressure calcs according to datasheet to extract pressure in Pa
   B6 = B5 - 4000;
   X1 = ((int32_t)b2 * ( (B6 * B6)>>12 )) >> 11;
   X2 = ((int32_t)ac2 * B6) >> 11;
@@ -195,6 +233,8 @@ int32_t Adafruit_BMP085::readPressure(void) {
 }
 
 int32_t Adafruit_BMP085::readSealevelPressure(float altitude_meters) {
+  // sea level pressure, e.g. standard barometric pressure based on local altitude
+  // formula from datasheet
   float pressure = readPressure();
   return (int32_t)(pressure / pow(1.0-altitude_meters/44330, 5.255));
 }
@@ -202,8 +242,11 @@ int32_t Adafruit_BMP085::readSealevelPressure(float altitude_meters) {
 float Adafruit_BMP085::readTemperature(void) {
   int32_t UT, B5;     // following ds convention
   float temp;
-
-  UT = readRawTemperature();
+  // use the latest raw value maintained by heartBeat() instead of needing 5 ms every call
+  //UT = readRawTemperature();
+  heartBeat();
+  while(micros()-lastT > 50000) heartBeat();     // Make sure data is recent
+  UT = rawT;
 
 #if BMP085_DEBUG == 1
   // use datasheet numbers!
@@ -222,6 +265,7 @@ float Adafruit_BMP085::readTemperature(void) {
 }
 
 float Adafruit_BMP085::readAltitude(float sealevelPressure) {
+  // altitude in metres based on sea level pressure 
   float altitude;
 
   float pressure = readPressure();

--- a/Adafruit_BMP085.h
+++ b/Adafruit_BMP085.h
@@ -62,7 +62,7 @@ class Adafruit_BMP085 {
   float readAltitude(float sealevelPressure = 101325); // std atmosphere
   uint16_t readRawTemperature(void);
   uint32_t readRawPressure(void);
-  void Adafruit_BMP085::heartBeat(void);
+  void heartBeat(void);
   
  private:
   int32_t computeB5(int32_t UT);

--- a/Adafruit_BMP085.h
+++ b/Adafruit_BMP085.h
@@ -62,6 +62,7 @@ class Adafruit_BMP085 {
   float readAltitude(float sealevelPressure = 101325); // std atmosphere
   uint16_t readRawTemperature(void);
   uint32_t readRawPressure(void);
+  void Adafruit_BMP085::heartBeat(void);
   
  private:
   int32_t computeB5(int32_t UT);
@@ -73,6 +74,10 @@ class Adafruit_BMP085 {
 
   int16_t ac1, ac2, ac3, b1, b2, mb, mc, md;
   uint16_t ac4, ac5, ac6;
+
+  uint32_t lastT = 0, lastP = 0;  // last readings of raw quantities 
+  uint16_t rawT = 0;
+  uint32_t rawP = 0;    // last raw values read
 };
 
 


### PR DESCRIPTION
Added .ino example in root allowing easy development / testing inside
Arduino IDE.

Added a bmp.heartBeat() function that can be called often to keep
pressure data current. If it is never called, pressure data will still
never be more than 50 ms out of date.

State machine design eliminates the wait of up to 31 ms to return from
a call to readPressure(), most of which was spent in delay. This change
allows the loop to run at around 20kHz instead of about 30Hz max with
delays().

Application interface remains the same.