### PR TITLE
Allow override of I2C pins the BMP is connected to

### DIFF
--- a/Adafruit_BMP085.cpp
+++ b/Adafruit_BMP085.cpp
@@ -22,11 +22,18 @@ Adafruit_BMP085::Adafruit_BMP085() {
 
 
 boolean Adafruit_BMP085::begin(uint8_t mode) {
+    return begin(0, 0, mode);
+}
+
+boolean Adafruit_BMP085::begin(uint8_t sda_pin, uint8_t scl_pin, uint8_t mode) {
   if (mode > BMP085_ULTRAHIGHRES) 
     mode = BMP085_ULTRAHIGHRES;
   oversampling = mode;
 
-  Wire.begin();
+  if (sda_pin == 0)
+      Wire.begin();
+  else
+      Wire.begin(sda_pin, scl_pin);
 
   if (read8(0xD0) != 0x55) return false;
 

--- a/Adafruit_BMP085.h
+++ b/Adafruit_BMP085.h
@@ -56,6 +56,7 @@ class Adafruit_BMP085 {
  public:
   Adafruit_BMP085();
   boolean begin(uint8_t mode = BMP085_ULTRAHIGHRES);  // by default go highres
+  boolean begin(uint8_t sda_pin, uint8_t scl_pin, uint8_t mode = BMP085_ULTRAHIGHRES);
   float readTemperature(void);
   int32_t readPressure(void);
   int32_t readSealevelPressure(float altitude_meters = 0);


### PR DESCRIPTION
The Arduino Wire library will use the platform's default SDA and SCL pins to communicate. However, it also allows one to specify which pin to use, as many platforms can make use of other pins to do I2C.
This PR allows a user of BMP085 lib to specify the pins it's connected to, BUT does not change the default behavior.