### PR TITLE
Init i2c_dev before use

### DIFF
--- a/Adafruit_BMP085.cpp
+++ b/Adafruit_BMP085.cpp
@@ -31,7 +31,9 @@
 #include "Adafruit_BMP085.h"
 #include <Adafruit_I2CDevice.h>
 
-Adafruit_BMP085::Adafruit_BMP085() {}
+Adafruit_BMP085::Adafruit_BMP085() {
+  i2c_dev = nullptr;
+}
 
 bool Adafruit_BMP085::begin(uint8_t mode, TwoWire *wire) {
   if (mode > BMP085_ULTRAHIGHRES)

--- a/Adafruit_BMP085.cpp
+++ b/Adafruit_BMP085.cpp
@@ -31,9 +31,7 @@
 #include "Adafruit_BMP085.h"
 #include <Adafruit_I2CDevice.h>
 
-Adafruit_BMP085::Adafruit_BMP085() {
-  i2c_dev = nullptr;
-}
+Adafruit_BMP085::Adafruit_BMP085() { i2c_dev = nullptr; }
 
 bool Adafruit_BMP085::begin(uint8_t mode, TwoWire *wire) {
   if (mode > BMP085_ULTRAHIGHRES)


### PR DESCRIPTION
`Adafruit_BMP085::begin` tries to delete `i2c_dev` before init. It may lead to random core dumps (on ESP8266 when Adafruit_BMP085 is created in dynamic object)