### PR TITLE
Fix description comments of functions

### DIFF
--- a/Adafruit_BMP085.h
+++ b/Adafruit_BMP085.h
@@ -87,12 +87,12 @@ public:
   float readAltitude(float sealevelPressure = 101325); // std atmosphere
   /*!
    * @brief Reads the raw temperature
-   * @return Returns signed 16-bit integer of the raw temperature
+   * @return Returns the raw temperature
    */
   uint16_t readRawTemperature(void);
   /*!
    * @brief Reads the raw pressure
-   * @return Returns signed 32-bit integer of the raw temperature
+   * @return Returns the raw pressure
    */
   uint32_t readRawPressure(void);
 


### PR DESCRIPTION
The description comments for the return types of
readRawTemperature() and readRawPressure() are
wrong. There is no point to add this information
in the comments anyway, as it is easily visible in the function declaration. In addition it is easy
to change the type and to forget to update the
comment too.